### PR TITLE
Fix #981 RBAC permissions missing from chart

### DIFF
--- a/charts/stash/templates/cluster-role.yaml
+++ b/charts/stash/templates/cluster-role.yaml
@@ -94,6 +94,7 @@ rules:
   - clusterroles
   - roles
   - rolebindings
+  - clusterrolebindings
   verbs: ["get", "create", "delete", "patch"]
 - apiGroups:
   - apps.openshift.io
@@ -119,4 +120,9 @@ rules:
     - volumesnapshots
     - volumesnapshotcontents
     - volumesnapshotclasses
-  verbs: ["create", "get", "list", "watch", "patch"]
+  verbs: ["create", "get", "list", "watch", "patch", "delete"]
+- apiGroups:
+    - storage.k8s.io
+  resources:
+    - storageclasses
+  verbs: ["get"]


### PR DESCRIPTION
RestoreSession creation was failing due to missing RBAC Permissions.

The following RBAC permissions were added for their respective API
Groups.
- `clusterrolebindings`
- `storageclasses`