### PR TITLE
Do not harcode namespace

### DIFF
--- a/charts/stash/templates/deployment.yaml
+++ b/charts/stash/templates/deployment.yaml
@@ -89,6 +89,8 @@ spec:
         args:
         - --web.listen-address=:56789
         - --persistence.file=/var/pv/pushgateway.dat
+        resources:
+{{ toYaml .Values.pushgateway.resources | indent 10 }}
         ports:
         - containerPort: 56789
         volumeMounts:

--- a/charts/stash/templates/deployment.yaml
+++ b/charts/stash/templates/deployment.yaml
@@ -10,6 +10,7 @@ metadata:
     {{- include "stash.labels" . | nindent 4 }}
 {{- if .Values.annotations }}
   annotations:
+    checksum/apiregistration.yaml: {{ include (print $.Template.BasePath "/apiregistration.yaml") . | sha256sum }}
 {{ toYaml .Values.annotations | indent 4 }}
 {{- end }}
 spec:

--- a/charts/stash/templates/deployment.yaml
+++ b/charts/stash/templates/deployment.yaml
@@ -1,3 +1,6 @@
+{{- $major := default "0" .Capabilities.KubeVersion.Major | trimSuffix "+" | int64 }}
+{{- $minor := default "0" .Capabilities.KubeVersion.Minor | trimSuffix "+" | int64 }}
+{{- $criticalAddon := and .Values.criticalAddon (or (eq .Release.Namespace "kube-system") (and (ge $major 1) (ge $minor 17))) -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -19,9 +22,9 @@ spec:
     metadata:
       labels:
         {{- include "stash.labels" . | nindent 8 }}
-{{- if or .Values.annotations (and .Values.criticalAddon (eq .Release.Namespace "kube-system")) }}
+{{- if or .Values.annotations $criticalAddon }}
       annotations:
-{{- if and .Values.criticalAddon (eq .Release.Namespace "kube-system") }}
+{{- if $criticalAddon }}
         scheduler.alpha.kubernetes.io/critical-pod: ''
 {{- end }}
 {{- if .Values.annotations }}
@@ -104,12 +107,12 @@ spec:
           secretName: {{ template "stash.fullname" . }}-apiserver-cert
       securityContext:
         fsGroup: 65535
-{{- if or .Values.tolerations (and .Values.criticalAddon (eq .Release.Namespace "kube-system")) }}
+{{- if or .Values.tolerations $criticalAddon }}
       tolerations:
 {{- if .Values.tolerations }}
 {{ toYaml .Values.tolerations | indent 8 }}
 {{- end -}}
-{{- if and .Values.criticalAddon (eq .Release.Namespace "kube-system") }}
+{{- if $criticalAddon }}
       - key: CriticalAddonsOnly
         operator: Exists
 {{- end -}}
@@ -122,6 +125,6 @@ spec:
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
 {{- end -}}
-{{- if and .Values.criticalAddon (eq .Release.Namespace "kube-system") }}
+{{- if $criticalAddon }}
       priorityClassName: system-cluster-critical
 {{- end -}}

--- a/charts/stash/templates/deployment.yaml
+++ b/charts/stash/templates/deployment.yaml
@@ -79,8 +79,7 @@ spec:
           initialDelaySeconds: 5
 {{- end }}
         resources:
-          requests:
-            cpu: "100m"
+{{ toYaml .Values.resources | indent 10 }}
         volumeMounts:
         - mountPath: /var/serving-cert
           name: serving-cert

--- a/charts/stash/values.yaml
+++ b/charts/stash/values.yaml
@@ -11,6 +11,7 @@ pushgateway:
   registry: prom
   repository: pushgateway
   tag: v0.5.2
+  resources: {}
 cleaner:
   registry: appscode
   repository: kubectl

--- a/charts/stash/values.yaml
+++ b/charts/stash/values.yaml
@@ -34,6 +34,10 @@ criticalAddon: false
 ## Log level for operator
 logLevel: 3
 
+resources:
+  requests:
+    cpu: "100m"
+
 ## Annotations passed to operator pod(s).
 ##
 annotations: {}


### PR DESCRIPTION
Is there any reason why documentation use `kube-system`?

I rather keep different apps in separated namespaces.