### PR TITLE
Add the possibility to specify webhook annotations

### DIFF
--- a/chart/stash/Chart.yaml
+++ b/chart/stash/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: 'Stash by AppsCode - Backup your Kubernetes Volumes'
 name: stash
-version: 0.8.3
+version: 0.8.4
 appVersion: 0.8.3
 home: https://github.com/appscode/stash
 icon: https://cdn.appscode.com/images/icon/stash.png

--- a/chart/stash/templates/mutating-webhook.yaml
+++ b/chart/stash/templates/mutating-webhook.yaml
@@ -11,6 +11,9 @@ metadata:
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
+    {{- if .Values.apiserver.mutatingWebhookAnnotations }}
+    {{- toYaml .Values.apiserver.mutatingWebhookAnnotations | nindent 4 }}
+    {{- end }}
 webhooks:
 - name: deployment.admission.stash.appscode.com
   clientConfig:

--- a/chart/stash/templates/validating-webhook.yaml
+++ b/chart/stash/templates/validating-webhook.yaml
@@ -11,6 +11,9 @@ metadata:
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
+    {{- if .Values.apiserver.validatingWebhookAnnotations }}
+    {{- toYaml .Values.apiserver.validatingWebhookAnnotations | nindent 4 }}
+    {{- end }}
 webhooks:
 - name: restic.admission.stash.appscode.com
   clientConfig:

--- a/chart/stash/values.yaml
+++ b/chart/stash/values.yaml
@@ -80,6 +80,10 @@ apiserver:
   enableValidatingWebhook: true
   # CA certificate used by main Kubernetes api server
   ca: not-ca-cert
+
+  mutatingWebhookAnnotations: {}
+  validatingWebhookAnnotations: {}
+
   # If true, disables status sub resource for crds.
   # Otherwise, enables status sub resource for Kubernetes version >= 1.11 and disables for other versions.
   disableStatusSubresource: false


### PR DESCRIPTION
This is needed to tweak the integration with CertManager: https://cert-manager.io/docs/concepts/ca-injector/

I opened this for release-0.8 because we use stash 0.8.3, but I guess it can be easy to replicate in latest master if you are happy with this PR