### PR TITLE
pass registry repository to operator

### DIFF
--- a/charts/stash/templates/deployment.yaml
+++ b/charts/stash/templates/deployment.yaml
@@ -44,7 +44,7 @@ spec:
         args:
         - run
         - --v={{ .Values.logLevel }}
-        - --docker-registry={{ .Values.operator.registry }}
+        - --docker-registry={{ .Values.operator.registry }}/{{ .Values.operator.repository }}
         - --image-tag={{ .Values.operator.tag }}
         - --secure-port=8443
         - --audit-log-path=-


### PR DESCRIPTION
Using registry is not enough, repository should be used as well

Signed-off-by: Dinar Valeev <k0da@opensuse.org>