### PR TITLE
Allow overwriting cleaner registry

### DIFF
--- a/charts/stash/templates/_helpers.tpl
+++ b/charts/stash/templates/_helpers.tpl
@@ -86,7 +86,7 @@ Returns the registry used for catalog docker images
 Returns the registry used for cleaner docker image
 */}}
 {{- define "cleaner.registry" -}}
-{{- default .Values.cleaner.registry .Values.global.registry }}
+{{- default .Values.global.registry .Values.cleaner.registry }}
 {{- end }}
 
 {{/*


### PR DESCRIPTION
Signed-off-by: Emruz Hossain <emruz@appscode.com>

**Previous behavior:**
- If `global.registry` is set, then use that registry for cleaner image.
- If `global.registry` is not set, then use the registry from the `cleaner.registry` of `values.yaml` file of the dependency chart.

**Why it is not sufficient?**
When we install the operator from `Makefile` it uses the registry from the `REGISTRY` env. As a result the cleaner image registry also get changed to that registry. So, if we want to use personal registry, or `appscodeci` test registry, we have to push the cleaner image there. Otherwise, the uninstall will get stuck.

**New behavior:**
This PR allow to use different registry for cleaner even when the `global.registry` is set. Now, current behavior is:
- If both `global.registry` and `cleaner.registry` are set, then use `cleaner.registry` for cleaner image.
- If only `global.registry` is set, then use `global.registry` for cleaner image.
- If only `cleaner.registry` is set, then use `cleaner.registry` for the cleaner image.
- If none of them are set, then user registry from `cleaner.registry` value from `values.yaml` file of the individual chart.
