### PR TITLE
removed duplicate yaml key

### DIFF
--- a/charts/stash-community/templates/license.yaml
+++ b/charts/stash-community/templates/license.yaml
@@ -8,7 +8,6 @@ metadata:
   labels:
   {{- include "stash-community.labels" . | nindent 4 }}
 type: Opaque
-type: Opaque
 data:
   key.txt: {{ include "appscode.license" . | b64enc }}
 {{- end }}


### PR DESCRIPTION
Duplicate keys in the helm yaml output causes panics in kyaml (https://github.com/kubernetes-sigs/kustomize/issues/3480). As a result, stash community chart can not be deployed by flux helm-controller.

This PR removes the duplicate `type` key from `license.yaml`.