### PR TITLE
Use authorization block and metrics-token secrets in ServiceMonitors

### DIFF
--- a/charts/stash-community/templates/metrics-token-secret.yaml
+++ b/charts/stash-community/templates/metrics-token-secret.yaml
@@ -1,0 +1,10 @@
+{{- if and (eq .Values.monitoring.agent "prometheus.io/operator") (or .Values.monitoring.backup .Values.monitoring.operator) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "stash-community.fullname" . }}-metrics-token
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    kubernetes.io/service-account.name: {{ include "stash-community.serviceAccountName" . }}
+type: kubernetes.io/service-account-token
+{{- end }}

--- a/charts/stash-community/templates/servicemonitor.yaml
+++ b/charts/stash-community/templates/servicemonitor.yaml
@@ -26,7 +26,11 @@ spec:
   {{- end }}
   {{- if .Values.monitoring.operator }}
   - port: api
-    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    authorization:
+      type: Bearer
+      credentials:
+        name: {{ include "stash-community.fullname" . }}-metrics-token
+        key: token
     scheme: https
     tlsConfig:
       ca:

--- a/charts/stash-enterprise/templates/metrics-token-secret.yaml
+++ b/charts/stash-enterprise/templates/metrics-token-secret.yaml
@@ -1,0 +1,10 @@
+{{- if and (eq .Values.monitoring.agent "prometheus.io/operator") (or .Values.monitoring.backup .Values.monitoring.operator) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "stash-enterprise.fullname" . }}-metrics-token
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    kubernetes.io/service-account.name: {{ include "stash-enterprise.serviceAccountName" . }}
+type: kubernetes.io/service-account-token
+{{- end }}

--- a/charts/stash-enterprise/templates/servicemonitor.yaml
+++ b/charts/stash-enterprise/templates/servicemonitor.yaml
@@ -26,7 +26,11 @@ spec:
   {{- end }}
   {{- if .Values.monitoring.operator }}
   - port: api
-    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    authorization:
+      type: Bearer
+      credentials:
+        name: {{ include "stash-enterprise.fullname" . }}-metrics-token
+        key: token
     scheme: https
     tlsConfig:
       ca:

--- a/charts/stash-ui-server/templates/metrics-token-secret.yaml
+++ b/charts/stash-ui-server/templates/metrics-token-secret.yaml
@@ -1,0 +1,10 @@
+{{- if eq "prometheus.io/operator" ( include "monitoring.agent" . ) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "stash-ui-server.fullname" . }}-metrics-token
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    kubernetes.io/service-account.name: {{ include "stash-ui-server.serviceAccountName" . }}
+type: kubernetes.io/service-account-token
+{{- end }}

--- a/charts/stash-ui-server/templates/servicemonitor.yaml
+++ b/charts/stash-ui-server/templates/servicemonitor.yaml
@@ -19,7 +19,11 @@ spec:
       {{- include "stash-ui-server.selectorLabels" . | nindent 6 }}
   endpoints:
   - port: api
-    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    authorization:
+      type: Bearer
+      credentials:
+        name: {{ include "stash-ui-server.fullname" . }}-metrics-token
+        key: token
     scheme: https
     tlsConfig:
       ca:

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/codegangsta/inject v0.0.0-20150114235600-33e0aa1cb7c0 // indirect
 	github.com/containerd/stargz-snapshotter/estargz v0.18.1 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
-	github.com/docker/cli v29.0.3+incompatible // indirect
+	github.com/docker/cli v29.2.0+incompatible // indirect
 	github.com/docker/distribution v2.8.3+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.9.4 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/docker/cli v29.0.3+incompatible h1:8J+PZIcF2xLd6h5sHPsp5pvvJA+Sr2wGQxHkRl53a1E=
-github.com/docker/cli v29.0.3+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
+github.com/docker/cli v29.2.0+incompatible h1:9oBd9+YM7rxjZLfyMGxjraKBKE4/nVyvVfN4qNl9XRM=
+github.com/docker/cli v29.2.0+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/distribution v2.8.3+incompatible h1:AtKxIZ36LoNK51+Z6RpzLpddBirtxJnzDrHLEKxTAYk=
 github.com/docker/distribution v2.8.3+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker-credential-helpers v0.9.4 h1:76ItO69/AP/V4yT9V4uuuItG0B1N8hvt0T0c0NN/DzI=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -17,7 +17,7 @@ github.com/containerd/stargz-snapshotter/estargz/errorutil
 # github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 ## explicit
 github.com/davecgh/go-spew/spew
-# github.com/docker/cli v29.0.3+incompatible
+# github.com/docker/cli v29.2.0+incompatible
 ## explicit
 github.com/docker/cli/cli/config
 github.com/docker/cli/cli/config/configfile


### PR DESCRIPTION
## Summary
- replace deprecated bearerTokenFile usage with ServiceMonitor authorization credentials blocks
- add per-chart long-lived ServiceAccount token Secret templates (type: kubernetes.io/service-account-token)
- use Secret names with the -metrics-token suffix: <fullname>-metrics-token
- wire ServiceMonitor credentials to key token in the corresponding metrics token Secret

## Why
Prometheus Operator rejects ServiceMonitor specs that use bearerTokenFile. This updates charts to the supported credentials-based auth style and avoids filesystem token references.

## Charts Updated
- stash-community
- stash-enterprise
- stash-ui-server

## Notes
- no new template helper added
- commit is signed off (DCO)
